### PR TITLE
fix: change access control of initializer

### DIFF
--- a/Sources/Presentation/External/SimpleToast.swift
+++ b/Sources/Presentation/External/SimpleToast.swift
@@ -25,7 +25,14 @@ public struct SimpleToast {
     internal var shape: SimpleToastShape = .roundedRectangle()
     internal var animationStyle: STKAnimationStyle = STKDefaults.animationStyle
     
-    init(message: String, holdSec: Double = STKDefaults.holdSec) {
+    // Initializer for only set message
+    public init(message: String) {
+        self.message = message
+        self.holdSec = STKDefaults.holdSec
+    }
+    
+    // Initializer fot set message with holdSec
+    public init(message: String, holdSec: Double) {
         self.message = message
         self.holdSec = holdSec
     }
@@ -34,13 +41,13 @@ public struct SimpleToast {
 // MARK: - SimpleToast Modifiers
 
 extension SimpleToast {
-    func toastAnimation(_ animation: STKAnimationStyle) -> SimpleToast {
+    public func toastAnimation(_ animation: STKAnimationStyle) -> SimpleToast {
         var copy = self
         copy.animationStyle = animation
         return copy
     }
     
-    func toastShape(_ shape: SimpleToastShape) -> SimpleToast {
+    public func toastShape(_ shape: SimpleToastShape) -> SimpleToast {
         var copy = self
         copy.shape = shape
         return copy


### PR DESCRIPTION
### Issue

- Close: #

---

### 🔴 Type of Work

- [ ] feat: Add new feature
- [x] fix: Bug fix
- [ ] refactor: Code refactoring
- [ ] style: Code cleanup, folder structure adjustments
- [ ] docs: Documentation updates
- [ ] chore: Release preparation work

---

### 🔵 Description

> Describe what was implemented or changed. Specify which views, features, or modules were affected.

- [x] Change access control of initializer

---

### 📋 Checklist

- [x] I have verified that there are no build errors.
- [x] The merge target branch is correct.
- [x] My code follows the project’s style guide and conventions.

---

### 📝 Notes for Reviewers

> Add any context, caveats, or points of attention for the reviewer.

- The initializer of SimpleToast was not accessible due to its access control level.
Made the initializer public and added an overloaded method for convenience.
