### PR TITLE
refactor: Enable Usecase Dendency Injection to ViewModel

### DIFF
--- a/Sources/Presentation/Internal/STKViewModel.swift
+++ b/Sources/Presentation/Internal/STKViewModel.swift
@@ -17,18 +17,29 @@ import Combine
 ///   This class is internal and not intended for direct use by external users.
 internal final class STKViewModel: ObservableObject {
     /// The shared singleton instance for managing the toast system.
-    @MainActor static let shared = STKViewModel(usecase: STKUseCase())
+    @MainActor static let shared = STKViewModel()
     
     /// The current state of the toast view.
     @Published private var state: State = State()
     
-    private let usecase: STKUseCaseProtocol
+    private var usecase: STKUseCaseProtocol = STKUseCase()
     private var cancellables: Set<AnyCancellable> = []
     
-    private init(usecase: STKUseCaseProtocol) {
+    #if DEBUG
+    /// Inject `STKUseCaseProtocol` type Usecase
+    ///
+    /// > Warning:
+    ///   This function is only for testing purpose.
+    ///   Do not use this for release code.
+    internal func injectUsecase(_ usecase: STKUseCaseProtocol) {
         self.usecase = usecase
+        
+        cancellables.removeAll()
         subscribeUsecase()
     }
+    #endif
+    
+    private init() {subscribeUsecase() }
     
     func subscribeUsecase() {
         usecase.toastActivation


### PR DESCRIPTION
### Issue

- Close: #32 

---

### 🔴 Type of Work

- [ ] feat: Add new feature
- [ ] fix: Bug fix
- [x] refactor: Code refactoring
- [ ] style: Code cleanup, folder structure adjustments
- [ ] docs: Documentation updates
- [ ] chore: Release preparation work

---

### 🔵 Description

> Describe what was implemented or changed. Specify which views, features, or modules were affected.

- [x] Add `injectUsecase` function that can inject `STKUseCaseProtocol` to `ViewModel`
---

### 📋 Checklist

- [x] I have verified that there are no build errors.
- [x] The merge target branch is correct.
- [x] My code follows the project’s style guide and conventions.

---

### 📝 Notes for Reviewers

> Add any context, caveats, or points of attention for the reviewer.

- I realized that `usecase` parameter in the initializer was useless since the initializer is private
 So I refactored it into separate `injectUsecase` function and wrapped it with `#if DEBUG` to ensure it's only used in test or debug environments.
